### PR TITLE
Fixing remote pod close

### DIFF
--- a/jinad/api/endpoints/flow.py
+++ b/jinad/api/endpoints/flow.py
@@ -122,6 +122,7 @@ def _create_from_yaml(
         try:
             # This makes sure `uses` & `py_modules` are created locally in `cwd`
             # TODO: Handle file creation, deletion better
+            # TODO: Do we need to add support for `uses_before`, `uses_after`?
             if uses_files:
                 [create_meta_files_from_upload(current_use_file) for current_use_file in uses_files]
 

--- a/jinad/remote.py
+++ b/jinad/remote.py
@@ -1,5 +1,6 @@
 import requests
 from fastapi import status
+from jina.helper import colored
 from jina.peapods.pea import BasePea
 
 from helper import namespace_to_dict
@@ -80,10 +81,9 @@ class RemoteMutablePod(BasePea):
             pea_args = namespace_to_dict(self.args)
             self.pod_id = self.pod_api.create(pea_args=pea_args)
             if self.pod_id:
-                self.logger.success(f'remote pod with id {self.pod_id} created')
+                self.logger.success(f'created remote pod with id {colored(self.pod_id, "cyan")} created')
                 self.set_ready()
                 
-                # TODO: this is blocking pod context. handle it
                 self.pod_api.log(pod_id=self.pod_id)
             else:
                 self.logger.error('remote pod creation failed')
@@ -91,11 +91,11 @@ class RemoteMutablePod(BasePea):
             self.logger.error('couldn\'t connect to the remote jinad')
             self.is_shutdown.set()
     
-    def loop_teardown(self):
+    def close(self):
         if self.pod_api.is_alive():
             status = self.pod_api.delete(pod_id=self.pod_id)
             if status:
-                self.logger.success(f'successfully closed pod with id {self.pod_id}')
+                self.logger.success(f'successfully closed pod with id {colored(self.pod_id, "cyan")}')
             else:
                 self.logger.error('remote pod close failed')
         else:

--- a/jinad/remote.py
+++ b/jinad/remote.py
@@ -81,7 +81,7 @@ class RemoteMutablePod(BasePea):
             pea_args = namespace_to_dict(self.args)
             self.pod_id = self.pod_api.create(pea_args=pea_args)
             if self.pod_id:
-                self.logger.success(f'created remote pod with id {colored(self.pod_id, "cyan")} created')
+                self.logger.success(f'created remote pod with id {colored(self.pod_id, "cyan")}')
                 self.set_ready()
                 
                 self.pod_api.log(pod_id=self.pod_id)


### PR DESCRIPTION
Making log stream from remote pod non-blocking - this unblocks the server from a blocking call, hence enabling the next set of calls (closing the pod)