### PR TITLE
Support for setting config via environment variables

### DIFF
--- a/jinad/api/endpoints/flow.py
+++ b/jinad/api/endpoints/flow.py
@@ -13,7 +13,7 @@ from store import flow_store
 from excepts import FlowYamlParseException, FlowCreationFailed, FlowStartFailed, \
     HTTPException, GRPCServerError
 from helper import Flow
-from config import openapitags_config
+from config import openapitags_config, hypercorn_config
 
 
 logger = JinaLogger(context='👻 FLOWAPI')
@@ -23,6 +23,7 @@ TAG = openapitags_config.FLOW_API_TAGS[0]['name']
 
 @router.on_event('startup')
 async def startup():
+    logger.info(f'Hypercorn + FastAPI running on {hypercorn_config.HOST}:{hypercorn_config.PORT}')
     logger.info('Welcome to Jina daemon. You can start playing with Flows!')
 
 

--- a/jinad/api/endpoints/pod.py
+++ b/jinad/api/endpoints/pod.py
@@ -11,7 +11,7 @@ from helper import dict_to_namespace, create_meta_files_from_upload
 from models.pod import PodModel
 from store import pod_store
 from excepts import HTTPException, PodStartFailed
-from config import openapitags_config
+from config import openapitags_config, hypercorn_config
 
 
 TAG = openapitags_config.POD_API_TAGS[0]['name']
@@ -21,6 +21,7 @@ router = APIRouter()
 
 @router.on_event('startup')
 async def startup():
+    logger.info(f'Hypercorn + FastAPI running on {hypercorn_config.HOST}:{hypercorn_config.PORT}')
     logger.info('Welcome to Jina daemon for remote pods')
 
 

--- a/jinad/config.py
+++ b/jinad/config.py
@@ -1,14 +1,19 @@
-from pydantic import BaseSettings
+from pydantic import BaseSettings, validator
 
 
-class FastAPIConfig(BaseSettings):
+class BaseConfig(BaseSettings):
+    class Config:
+        env_prefix = 'JINAD_'
+
+
+class FastAPIConfig(BaseConfig):
     NAME: str = 'Jina Flow Manager'
     DESCRIPTION: str = 'REST API for creating/deleting Jina Flow'
     VERSION: str = '0.1.0'
     PREFIX: str = '/v1'
     
 
-class OpenAPITags(BaseSettings):
+class OpenAPITags(BaseConfig):
     FLOW_API_TAGS: list = [{
         "name": "Flow Manager",
         "description": "API to invoke local/remote Flows",
@@ -31,11 +36,22 @@ class OpenAPITags(BaseSettings):
     }]
 
 
-class HypercornConfig(BaseSettings):
+class HypercornConfig(BaseConfig):
     HOST: str = '0.0.0.0'
     PORT: int = 8000
 
 
+class JinaDConfig(BaseConfig):
+    CONTEXT: str = 'flow'
+
+    @validator('CONTEXT')
+    def name_must_contain_space(cls, value):
+        if value.lower() not in ['flow', 'pod']:
+            raise ValueError('CONTEXT must be either flow or pod')
+        return value.lower()
+
+
+jinad_config = JinaDConfig()
 fastapi_config = FastAPIConfig()
 hypercorn_config = HypercornConfig()
 openapitags_config = OpenAPITags()

--- a/jinad/main.py
+++ b/jinad/main.py
@@ -7,10 +7,11 @@ from hypercorn.config import Config
 from hypercorn.asyncio import serve
 
 from api.endpoints import flow, pod
-from config import fastapi_config, hypercorn_config, openapitags_config
+from config import jinad_config, fastapi_config, \
+    hypercorn_config, openapitags_config
 
 
-def main(invocation: str = 'flow'):
+def main():
     """Entrypoint to the api
 
     Args:
@@ -23,11 +24,11 @@ def main(invocation: str = 'flow'):
         version=fastapi_config.VERSION
     )
     
-    if invocation == 'flow':
+    if jinad_config.CONTEXT == 'flow':
         app.openapi_tags = openapitags_config.FLOW_API_TAGS
         app.include_router(router=flow.router,
                            prefix=fastapi_config.PREFIX)
-    elif invocation == 'pod':
+    elif jinad_config.CONTEXT == 'pod':
         app.openapi_tags = openapitags_config.POD_API_TAGS
         app.include_router(router=pod.router,
                            prefix=fastapi_config.PREFIX)
@@ -56,4 +57,4 @@ def hc_serve(f_app: 'FastAPI'):
 
 
 if __name__ == "__main__":
-    main(invocation='flow')
+    main()


### PR DESCRIPTION
Since we use Pydantic based settings management, I've added a way to set configs via environment variables. (solves #14 )
e.g. -
`export JINAD_PORT=8002` & starting `main.py` makes hypercorn run on 8002 (default: 8000)
`export JINAD_CONTEXT=pod` & starting `main.py` starts app context as a remote pod