### PR TITLE
RemotePod via jina cli

### DIFF
--- a/jinad/api/endpoints/pea.py
+++ b/jinad/api/endpoints/pea.py
@@ -8,7 +8,7 @@ from fastapi.responses import StreamingResponse
 
 from store import pea_store
 from models.pea import PeaModel
-from helper import pea_dict_to_namespace, create_meta_files_from_upload
+from helper import basepea_to_namespace, create_meta_files_from_upload
 from excepts import HTTPException, PeaStartException
 from config import openapitags_config, hypercorn_config
 
@@ -62,7 +62,7 @@ async def _create(
     """
     Used to create a Pea on remote
     """
-    pea_arguments = pea_dict_to_namespace(args=pea_arguments)
+    pea_arguments = basepea_to_namespace(args=pea_arguments)
 
     with pea_store._session():
         try:

--- a/jinad/helper.py
+++ b/jinad/helper.py
@@ -6,6 +6,7 @@ from jina.peapods.pea import BasePea
 from jina.excepts import FlowTopologyError
 from fastapi import UploadFile
 
+from models.pod import PodModel
 from models.pea import PeaModel
 
 
@@ -38,7 +39,7 @@ def handle_enums(args: Dict, parser: argparse.ArgumentParser):
     return _args
 
 
-def pod_dict_to_namespace(args: Dict):
+def flowpod_to_namespace(args: Dict):
     from jina.parser import set_pod_parser
     parser = set_pod_parser()
     pod_args = {}
@@ -65,7 +66,17 @@ def pod_dict_to_namespace(args: Dict):
     return pod_args
 
 
-def pea_dict_to_namespace(args: PeaModel):
+def basepod_to_namespace(args: PodModel):
+    from jina.parser import set_pod_parser
+    parser = set_pod_parser()
+
+    if isinstance(args, PodModel):
+        pod_args = handle_enums(args=args.dict(),
+                                parser=parser)
+        return argparse.Namespace(**pod_args)
+
+
+def basepea_to_namespace(args: PeaModel):
     from jina.parser import set_pea_parser
     parser = set_pea_parser()
 

--- a/jinad/models/custom.py
+++ b/jinad/models/custom.py
@@ -77,15 +77,6 @@ class PydanticConfig:
     arbitrary_types_allowed = True
 
 
-class PodPydanticConfig(PydanticConfig):
-    schema_extra = {
-        "example": {
-            "name": "pod1",
-            "uses": "_pass"
-        }
-    }
-
-
 def build_pydantic_model(kind: str = 'local',
                          model_name: str = 'CustomModel',
                          module: str = 'pod'):
@@ -105,8 +96,7 @@ def build_pydantic_model(kind: str = 'local',
             parser = set_flow_parser()
         all_fields, field_validators = get_pydantic_fields(config=parser)
 
-    config_class = PodPydanticConfig if module == 'pod' else PydanticConfig
     return create_model(model_name,
                         **all_fields,
-                        __config__=config_class,
+                        __config__=PydanticConfig,
                         __validators__=field_validators)


### PR DESCRIPTION
`jinad` already had support for `RemoteMutablePod` (FlowPod created in a Flow context). This PR adds support for `RemotePod` (an independent Pod created usually using the CLI)